### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_panasonic_heatpump.yml
+++ b/.github/workflows/test_panasonic_heatpump.yml
@@ -1,5 +1,8 @@
 name: Test Panasonic Heatpump Component
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/ElVit/esphome_components/security/code-scanning/7](https://github.com/ElVit/esphome_components/security/code-scanning/7)

Add an explicit top-level `permissions` block in `.github/workflows/test_panasonic_heatpump.yml` so all jobs inherit least-privilege token access by default.

Best single fix (without changing functionality):  
- Insert at workflow root (after `name:` and before `on:`):
  - `permissions:`
  - `contents: read`

This is sufficient for `actions/checkout@v4` and typical read-only CI tasks. No additional imports, methods, or dependencies are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
